### PR TITLE
In envetcd get the default route and use it as ETCD_ENDPOINT

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
   * Start feature "In envetcd get the default route and use it as ETCD_ENDPOINT"
   https://www.pivotaltracker.com/story/show/92456914
+  https://github.com/zvelo/envetcd/pull/9
 
 2014-12-15  Luke Kingland <lkingland@zvelo.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-04-15  Jonathan Briggs <jbriggs@zvelo.com>
+
+  * Start feature "In envetcd get the default route and use it as ETCD_ENDPOINT"
+  https://www.pivotaltracker.com/story/show/92456914
+
 2014-12-15  Luke Kingland <lkingland@zvelo.com>
 
   * Start feature "envetcd should provide a few more variables by default"

--- a/cmd/envetcd/cli.go
+++ b/cmd/envetcd/cli.go
@@ -27,14 +27,15 @@ const (
 
 func genConfig(c *cli.Context) {
 	config.EnvEtcd = &envetcd.Config{
-		Hostname: c.GlobalString("hostname"),
-		System:   c.GlobalString("system"),
-		Service:  c.GlobalString("service"),
-		Peers:    c.GlobalStringSlice("peers"),
-		Sync:     !c.GlobalBool("no-sync"),
-		Prefix:   c.GlobalString("prefix"),
-		Sanitize: !c.GlobalBool("no-sanitize"),
-		Upcase:   !c.GlobalBool("no-upcase"),
+		Hostname:          c.GlobalString("hostname"),
+		System:            c.GlobalString("system"),
+		Service:           c.GlobalString("service"),
+		Peers:             c.GlobalStringSlice("peers"),
+		Sync:              !c.GlobalBool("no-sync"),
+		Prefix:            c.GlobalString("prefix"),
+		Sanitize:          !c.GlobalBool("no-sanitize"),
+		Upcase:            !c.GlobalBool("no-upcase"),
+		UseDefaultGateway: c.GlobalBool("use-default-gateway"),
 		TLS: &transport.TLSInfo{
 			CAFile:   c.GlobalString("ca-file"),
 			CertFile: c.GlobalString("cert-file"),

--- a/cmd/envetcd/main.go
+++ b/cmd/envetcd/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	version = "0.1.1"
+	version = "0.1.2"
 )
 
 var (
@@ -103,6 +103,11 @@ func init() {
 			Name:   "no-upcase",
 			EnvVar: "ENVETCD_NO_UPCASE",
 			Usage:  "don't convert all environment keys to uppercase",
+		},
+		cli.BoolFlag{
+			Name:   "use-default-gateway, d",
+			EnvVar: "ENVETCD_USE_DEFAULT_GATEWAY",
+			Usage:  "expose the default gateway as $ENVETCD_DEFAULT_GATEWAY",
 		},
 	}
 	app.Action = run

--- a/default_route.go
+++ b/default_route.go
@@ -1,0 +1,49 @@
+package envetcd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"os"
+)
+
+// This will read /proc/net/route and look for an IPv4 default gateway.
+// IPv6 gateways will not be found.
+// It will then return the gateway as an IP.
+func getDefaultRouteGateway() (ip net.IP, err error) {
+	file, err := os.Open("/proc/net/route")
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	return scanRouteFile(file)
+}
+
+func scanRouteFile(input io.Reader) (ip net.IP, err error) {
+	scanner := bufio.NewScanner(input)
+	defaultRoute := net.IPv4(0, 0, 0, 0)
+	for scanner.Scan() {
+		var iface string
+		var destBytes, gatewayBytes []byte
+		conversions, _ := fmt.Sscanf(scanner.Text(), "%s %x %x", &iface, &destBytes, &gatewayBytes)
+		if conversions == 3 {
+			dest := net.IP(destBytes)
+			if dest.Equal(defaultRoute) {
+				ip = net.IP(reverseBytes(gatewayBytes))
+			}
+		}
+	}
+	err = scanner.Err()
+	return
+}
+
+func reverseBytes(slice []byte) []byte {
+	result := make([]byte, len(slice), cap(slice))
+	i := len(slice) - 1
+	for _, b := range slice {
+		result[i] = b
+		i--
+	}
+	return result
+}

--- a/default_route.go
+++ b/default_route.go
@@ -6,12 +6,17 @@ import (
 	"io"
 	"net"
 	"os"
+	"runtime"
 )
 
 // This will read /proc/net/route and look for an IPv4 default gateway.
 // IPv6 gateways will not be found.
 // It will then return the gateway as an IP.
 func getDefaultRouteGateway() (ip net.IP, err error) {
+	if runtime.GOOS != "linux" {
+		return ip, fmt.Errorf("not attempting to determine default gateway on non-linux OS")
+	}
+
 	file, err := os.Open("/proc/net/route")
 	if err != nil {
 		return

--- a/default_route_test.go
+++ b/default_route_test.go
@@ -15,7 +15,7 @@ func TestGetRoute(t *testing.T) {
 			ip, err := getDefaultRouteGateway()
 			So(ip, ShouldNotBeEmpty)
 			So(err, ShouldBeNil)
-		case "darwin":
+		default:
 			ip, err := getDefaultRouteGateway()
 			So(ip, ShouldBeEmpty)
 			So(err, ShouldNotBeNil)

--- a/default_route_test.go
+++ b/default_route_test.go
@@ -1,6 +1,7 @@
 package envetcd
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 
@@ -9,9 +10,17 @@ import (
 
 func TestGetRoute(t *testing.T) {
 	Convey("Getting default gateway", t, func() {
-		ip, err := getDefaultRouteGateway()
-		So(ip, ShouldNotBeEmpty)
-		So(err, ShouldBeNil)
+		switch runtime.GOOS {
+		case "linux":
+			ip, err := getDefaultRouteGateway()
+			So(ip, ShouldNotBeEmpty)
+			So(err, ShouldBeNil)
+		case "darwin":
+			ip, err := getDefaultRouteGateway()
+			So(ip, ShouldBeEmpty)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "not attempting to determine default gateway on non-linux OS")
+		}
 	})
 }
 

--- a/default_route_test.go
+++ b/default_route_test.go
@@ -1,0 +1,35 @@
+package envetcd
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGetRoute(t *testing.T) {
+	Convey("Getting default gateway", t, func() {
+		ip, err := getDefaultRouteGateway()
+		So(ip, ShouldNotBeEmpty)
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestGetRouteCorrectly(t *testing.T) {
+	Convey("Given a sample route file", t, func() {
+		input := strings.NewReader(
+			`Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
+wlp6s0	00000000	010C150A	0003	0	0	600	00000000	0	0	0                                                                           
+wlp6s0	000C150A	00000000	0001	0	0	0	00FFFFFF	0	0	0                                                                             
+wlp6s0	000C150A	00000000	0001	0	0	600	00FFFFFF	0	0	0                                                                           
+virbr1	000811AC	00000000	0001	0	0	0	00FFFFFF	0	0	0                                                                             
+virbr0	007CA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0  `,
+		)
+		ip, err := scanRouteFile(input)
+		So(ip, ShouldNotBeEmpty)
+		So(err, ShouldBeNil)
+		Convey("Gateway IP should be the IP from the file", func() {
+			So(ip.String(), ShouldEqual, "10.21.12.1")
+		})
+	})
+}

--- a/envetcd.go
+++ b/envetcd.go
@@ -3,6 +3,7 @@ package envetcd
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"regexp"
@@ -94,7 +95,7 @@ func getClient(config *Config) (*etcd.Client, error) {
 // Set modifies the current environment with variables retrieved from etcd. Set
 // will not overwrite existing variables.
 // The only required environment variable is $ETCD_ENDPOINT.
-// $ETCD_ENDPOINT should look like "http://127.0.0.1:401".
+// $ETCD_ENDPOINT should look like "http://127.0.0.1:4001".
 // service should be set by the application calling Set and not derived from
 // an environment variable.
 // Set will also use some other environment variables if they exist.
@@ -103,7 +104,12 @@ func getClient(config *Config) (*etcd.Client, error) {
 func Set(service string) error {
 	etcdEndpoint := os.Getenv("ETCD_ENDPOINT")
 	if len(etcdEndpoint) == 0 {
-		return nil
+		// Look for the default gateway and use that.
+		gatewayIP, err := getDefaultRouteGateway()
+		if err != nil {
+			return err
+		}
+		etcdEndpoint = fmt.Sprintf("http://%s:4001", gatewayIP.String())
 	}
 
 	config := &Config{

--- a/envetcd.go
+++ b/envetcd.go
@@ -102,13 +102,14 @@ func getClient(config *Config) (*etcd.Client, error) {
 // $ETCD_PREFIX defaults to "/config"
 // $HOSTNAME will be honored if it is set.
 func Set(service string) error {
+	gatewayIP, err := getDefaultRouteGateway()
+	if err != nil {
+		return err
+	}
+	os.Setenv("ENVETCD_DEFAULT_GATEWAY", gatewayIP.String())
+
 	etcdEndpoint := os.Getenv("ETCD_ENDPOINT")
 	if len(etcdEndpoint) == 0 {
-		// Look for the default gateway and use that.
-		gatewayIP, err := getDefaultRouteGateway()
-		if err != nil {
-			return err
-		}
 		etcdEndpoint = fmt.Sprintf("http://%s:4001", gatewayIP.String())
 	}
 

--- a/envetcd.go
+++ b/envetcd.go
@@ -128,7 +128,9 @@ func Set(service string) error {
 
 	useDefaultGateway := true
 	if len(os.Getenv("ENVETCD_USE_DEFAULT_GATEWAY")) > 0 {
-		if val, err := strconv.ParseBool(os.Getenv("ENVETCD_USE_DEFAULT_GATEWAY")); err == nil {
+		if val, err := strconv.ParseBool(os.Getenv("ENVETCD_USE_DEFAULT_GATEWAY")); err != nil {
+			log.Printf("[INFO] envetcd.Set could not parse $ENVETCD_USE_DEFAULT_GATEWAY, defaulting to true: %v\n", err)
+		} else {
 			useDefaultGateway = val
 		}
 	}

--- a/envetcd.goconvey
+++ b/envetcd.goconvey
@@ -1,0 +1,1 @@
+-timeout=10s

--- a/envetcd_test.go
+++ b/envetcd_test.go
@@ -32,7 +32,9 @@ func init() {
 
 func TestEtcd(t *testing.T) {
 	Convey("When getting keys from etcd", t, func() {
-		So(os.Getenv("ETCD_ENDPOINT"), ShouldNotBeEmpty)
+		Convey("ETCD_ENDPOINT environment variable", func() {
+			So(os.Getenv("ETCD_ENDPOINT"), ShouldNotBeBlank)
+		})
 
 		client := etcd.NewClient(config.Peers)
 		client.SetDir("/config/system/general", 0)


### PR DESCRIPTION
The default route gateway of a container is also the IP of the container host and is the IP that should be used for contacting many services.

Also export the default route as an environment variable (`$ENVETCD_DEFAULT_ROUTE`).

The easiest way to get this is probably reading /proc/net/route

PIVOTAL_TRACKER_STORY_URL=https://www.pivotaltracker.com/story/show/92456914
PIVOTAL_TRACKER_STORY_TYPE=feature
PIVOTAL_TRACKER_STORY_ESTIMATE=1
PIVOTAL_TRACKER_STORY_OWNER=jonathanbriggs3
PIVOTAL_TRACKER_STORY_REQUESTER=jonathanbriggs3
PIVOTAL_TRACKER_STORY_LABELS=envetcd